### PR TITLE
one pep8 + goodie

### DIFF
--- a/pyFilter/exceptions.py
+++ b/pyFilter/exceptions.py
@@ -1,5 +1,2 @@
 class DatabaseConfigException(Exception):
-    """Raises when the database supplied in the config does not match sqlite/redis"""
-
-
-
+    "Raises when the database supplied in the config does not match sqlite/redis"


### PR DESCRIPTION
too many trailing newlines, why use `"""` for something that clearly fits on one line?