### PR TITLE
Allow glob pattern matching on log files

### DIFF
--- a/Config/config.default.json
+++ b/Config/config.default.json
@@ -8,7 +8,7 @@
     "reload_iptables": true,
     "rules": {
       "ssh": {
-        "log_file": "/var/log/auth.log",
+        "log_files": "/var/log/auth.log",
         "regex_patterns": [
           "([a-zA-Z]{3}\\s+\\d{1,2} \\d{1,2}:\\d{1,2}:\\d{1,2}).* Invalid user .* from (.*) port (.*)",
           "([a-zA-Z]{3}\\s+\\d{1,2} \\d{1,2}:\\d{1,2}:\\d{1,2}).* Failed password for .* from (.*) port (.*)",
@@ -20,14 +20,14 @@
         "time_format": "%b %d %H:%M:%S"
       },
       "mysql": {
-        "log_file": "",
+        "log_files": "",
         "regex_patterns": [
           "(\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}) .* Access denied for user '.*'@'(.*)' .*"
         ],
         "time_format": "%Y-%m-%d  %H:%M:%S"
       },
       "apache": {
-        "log_file": "",
+        "log_files": "",
         "regex_patterns": [
           ["(.*) .* .* \\[(.*) \\+0000\\] \"POST ({}) HTTP/1\\.1\" .*", "urls"]
         ],
@@ -36,7 +36,7 @@
         "http_status_blocks": [200]
       },
       "nginx": {
-        "log_file": "",
+        "log_files": "",
         "regex_patterns": [
           ["(.*) .* .* \\[(.*) \\+0000\\] \"POST ({}) HTTP/1\\.1\" .*", "urls"]
         ],

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Configuration:
     "reload_iptables": true,
     "rules": {
       "ssh": {
-        "log_file": "/var/log/auth.log",
+        "log_files": "/var/log/auth.log",
         "regex_patterns": [
           "([a-zA-Z]{3}\\s+\\d{1,2} \\d{1,2}:\\d{1,2}:\\d{1,2}).* Invalid user .* from (.*) port (.*)",
           "([a-zA-Z]{3}\\s+\\d{1,2} \\d{1,2}:\\d{1,2}:\\d{1,2}).* Failed password for .* from (.*) port (.*)",
@@ -82,14 +82,14 @@ Configuration:
         "time_format": "%b %d %H:%M:%S"
       },
       "mysql": {
-        "log_file": "",
+        "log_files": "",
         "regex_patterns": [
           "(\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}) .* Access denied for user '.*'@'(.*)' .*"
         ],
         "time_format": "%Y-%m-%d  %H:%M:%S"
       },
       "apache": {
-        "log_file": "",
+        "log_files": "",
         "regex_patterns": [
           ["(.*) .* .* \\[(.*) \\+0000\\] \"POST ({}) HTTP/1\\.1\" .*", "urls"]
         ],
@@ -98,7 +98,7 @@ Configuration:
         "http_status_blocks": [200]
       },
       "nginx": {
-        "log_file": "",
+        "log_files": "",
         "regex_patterns": [
           ["(.*) .* .* \\[(.*) \\+0000\\] \"POST ({}) HTTP/1\\.1\" .*", "urls"]
         ],
@@ -147,7 +147,7 @@ To swap from sqlite to redis, change the current value `"database": "sqlite"` to
 
 ### Log files
 
-`"log_file": "/var/log/auth.log"` This will read from the specified file, and add bans as the events happen. 
+`"log_files": "/var/log/auth.log"` OR `"log_files": "/var/log/*.log"` This will read from the specified file, or specified pattern of files, and add bans as the events happen. See allowed glob patterns [here.](https://docs.python.org/3/library/fnmatch.html#fnmatch.fnmatch)
 
 ### Regex patterns
 

--- a/pyFilter/py_filter.py
+++ b/pyFilter/py_filter.py
@@ -5,6 +5,7 @@ import socket
 import subprocess
 import threading
 import time
+import glob
 
 try:
     import geoip2.database
@@ -376,18 +377,18 @@ class PyFilter(object):
         threads = []
 
         for key in self.rules:
+            log_files_pattern = self.rules[key]["log_files"]
 
-            log_file = self.rules[key]["log_file"]
-
-            if not log_file:
-                print("No file to check within rule: {}".format(key.title()))
+            if not log_files_pattern:
+                print("No log files pattern to check within rule: {}".format(key.title()))
                 continue
 
-            if not os.path.isfile(log_file):
-                print("WARNING: file {} could not be found".format(log_file))
-                continue
+            for log_file in glob.glob(log_files_pattern):
+                if not os.path.isfile(log_file):
+                    print("WARNING: file {} could not be found".format(log_file))
+                    continue
 
-            threads.append(threading.Thread(target=self.read_files, args=(log_file, key), name=key))
+                threads.append(threading.Thread(target=self.read_files, args=(log_file, key), name=key))
 
         threads.append(threading.Thread(target=self.make_persistent, name="persistent"))
 


### PR DESCRIPTION
# Glob pattern matching

Resolves #17 

***NOTE:*** There is a config change `log_file` -> `log_files`, this must be updated!

This change allows log files to be pattern matched via glob. This will allow a range of log files to be read for the same configuration, for example, the issue above `{domain}.log` which would translate to a glob pattern of `*.log`.